### PR TITLE
Renamed group to WordPress South Africa

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# WordPress Cape Town Slack - Code of Conduct
+# WordPress South Africa (WPSA) Slack - Code of Conduct
 
 ## TL;DR
 
@@ -14,13 +14,13 @@ This is a safe space, let's keep it that way.
 
 ## Code of Conduct
 
-“WordPress Cape Town” in this document refers to the WordPress Cape Town Slack organization at [https://wpcapetown.slack.com/](https://wpcapetown.slack.com/). “The administrators” refers to the administrators on this organization, a [list is available at the top of the Team Directory](https://wpcapetown.slack.com/team) (must be a member of the organization to view).
+“WPSA” in this document refers to the WordPress South Africa Slack organization at [https://wpcapetown.slack.com/](https://wpcapetown.slack.com/). “The administrators” refers to the administrators on this organization, a [list is available at the top of the Team Directory](https://wpcapetown.slack.com/team) (must be a member of the organization to view).
 
-WordPress Cape Town is dedicated to providing a harassment-free experience for everyone. We do not tolerate harassment of participants in any form.
+WPSA is dedicated to providing a harassment-free experience for everyone. We do not tolerate harassment of participants in any form.
 
-This code of conduct applies to all WordPress Cape Town spaces, including public channels, private channels and direct messages, both online and off. Anyone who violates this code of conduct may be sanctioned or expelled from these spaces at the discretion of the administrators.
+This code of conduct applies to all WPSA spaces, including public channels, private channels and direct messages, both online and off. Anyone who violates this code of conduct may be sanctioned or expelled from these spaces at the discretion of the administrators.
 
-Some WordPress Cape Town spaces may have additional rules in place, which will be made clearly available to participants. Participants are responsible for knowing and abiding by these rules.
+Some WPSA spaces may have additional rules in place, which will be made clearly available to participants. Participants are responsible for knowing and abiding by these rules.
 
 Harassment includes:
 
@@ -43,10 +43,10 @@ Harassment includes:
 
 ## Conduct specific to recruitment activities
 
-The WordPress Cape Town group, and its admins, acknowledge that finding skilled people in South Africa is a serious problem that needs serious attention. However, the WordPress Cape Town slack channel is first and foremost a safe space for people to talk, share and collaborate. Therefore, the following are specific conditions regarding recruitment, and recruitment opportunities.
+The WPSA group, and its admins, acknowledge that finding skilled people in South Africa is a serious problem that needs serious attention. However, the WPSA slack channel is first and foremost a safe space for people to talk, share and collaborate. Therefore, the following are specific conditions regarding recruitment, and recruitment opportunities.
 
-* Unsolicited professional recruiting is not allowed on the WordPress Cape Town group under any circumstances.
-* Users (including admins) may not under any circumstances share personal details of WordPress Cape Town members with recruiters without that user's explicit consent.
+* Unsolicited professional recruiting is not allowed on the WPSA group under any circumstances.
+* Users (including admins) may not under any circumstances share personal details of WPSA members with recruiters without that user's explicit consent.
 * Advertising an opportunity in brief within the [#jobpostings channel](https://wpcapetown.slack.com/messages/jobpostings/) is acceptable. Further discussions must happen via direct messages.
 * Opportunities must not, under any circumstances, use referral program links where the poster of the message could benefit, e.g. via earning a commission.
 
@@ -58,16 +58,16 @@ While the community aims to be a place for members of the community to meet and 
 
 ## Reporting
 
-If you are being harassed by a member of WordPress Cape Town, notice that someone else is being harassed, or have any other concerns, please [contact an admin](https://wpcapetown.slack.com/team) directly via DM. Administrators will respond as soon as they are able. If the person who is harassing you is on the admin team, they will recuse themselves from handling your incident.
+If you are being harassed by a member of WPSA, notice that someone else is being harassed, or have any other concerns, please [contact an admin](https://wpcapetown.slack.com/team) directly via DM. Administrators will respond as soon as they are able. If the person who is harassing you is on the admin team, they will recuse themselves from handling your incident.
 
-This code of conduct applies to WordPress Cape Town spaces, but if you are being harassed by a member of WordPress Cape Town outside of our spaces, we still want to know about it. We will take all good-faith reports of harassment by WordPress Cape Town members, especially the administrators, seriously. This includes harassment outside our spaces and harassment that took place at any point in time. The abuse team reserves the right to exclude people from WordPress Cape Town based on their past behavior, including behavior outside WordPress Cape Town spaces and behavior towards people who are not members of the WordPress Cape Town community.
+This code of conduct applies to WPSA spaces, but if you are being harassed by a member of WPSA outside of our spaces, we still want to know about it. We will take all good-faith reports of harassment by WPSA members, especially the administrators, seriously. This includes harassment outside our spaces and harassment that took place at any point in time. The abuse team reserves the right to exclude people from WPSA based on their past behavior, including behavior outside WPSA spaces and behavior towards people who are not members of the WPSA community.
 
 In order to protect volunteers from abuse and burnout, we reserve the right to reject any report we believe to have been made in bad faith. Reports intended to silence legitimate criticism may be deleted without response.
 
-We will respect confidentiality requests for the purpose of protecting victims of abuse. At our discretion, we may publicly name a person about whom we’ve received harassment complaints, or privately warn third parties about them, if we believe that doing so will increase the safety of WordPress Cape Town members or the general public. We will not name harassment victims without their affirmative consent.
+We will respect confidentiality requests for the purpose of protecting victims of abuse. At our discretion, we may publicly name a person about whom we’ve received harassment complaints, or privately warn third parties about them, if we believe that doing so will increase the safety of WPSA members or the general public. We will not name harassment victims without their affirmative consent.
 
 ## Acceptable Content
-The WordPress Cape Town community is a collection of professionals, as such it is expected that the content made available by members of the community should at all times adhere to the acceptable content policy. This policy is intended to protect the community's image, as well as the image of its members, through restrictions on certain classes of content which may be deemed to be unsuitable in a work or family context.
+The WPSA community is a collection of professionals, as such it is expected that the content made available by members of the community should at all times adhere to the acceptable content policy. This policy is intended to protect the community's image, as well as the image of its members, through restrictions on certain classes of content which may be deemed to be unsuitable in a work or family context.
 
 Classes of content which we deem to be unsuitable include:
 
@@ -76,15 +76,15 @@ Classes of content which we deem to be unsuitable include:
  - Persecution of any individual as a result of their race, gender, religion or other physical traits.
  - Material intended to, without basis, harm the reputation of any individual whether a member or not.
  - Unsolicited advertising with the exception of job offers in the [#jobpostings](https://wpcapetown.slack.com/messages/jobpostings/) channel.
- - Links, or links to pages, for the purpose of monetization of user views and which provide no value to the WordPress Cape Town community.
+ - Links, or links to pages, for the purpose of monetization of user views and which provide no value to the WPSA community.
 
-As a quick self-check, ask yourself whether you would like someone's child to see the content you are posting. If the answer is "no", then there's a good chance you shouldn't be posting it on the WordPress Cape Town community.
+As a quick self-check, ask yourself whether you would like someone's child to see the content you are posting. If the answer is "no", then there's a good chance you shouldn't be posting it on the WPSA community.
 
 ## Consequences
 
 Participants asked to stop any harassing behavior are expected to comply immediately.
 
-If a participant engages in harassing behavior, the administrators may take any action they deem appropriate, up to and including expulsion from all WordPress Cape Town spaces and identification of the participant as a harasser to other WordPress Cape Town members and/or the general public.
+If a participant engages in harassing behavior, the administrators may take any action they deem appropriate, up to and including expulsion from all WPSA spaces and identification of the participant as a harasser to other WPSA members and/or the general public.
 
 Intentionally evading exclusions, bans, suspensions, restrictions, or otherwise interfering with the admin team's decisions and actions are not permitted.
 


### PR DESCRIPTION
Updating group naming conventions
Fixes #1 